### PR TITLE
Re-enable HEVC muxing, enable correct configurationVersion

### DIFF
--- a/hevc.c
+++ b/hevc.c
@@ -44,7 +44,7 @@
 #define HEVC_MAX_SPS_ID             15
 #define HEVC_MAX_PPS_ID             63
 #define HEVC_MAX_DPB_SIZE           16
-#define HVCC_CONFIGURATION_VERSION  0   /* Fix this value when the NAL file format is finalized. */
+#define HVCC_CONFIGURATION_VERSION  1
 
 typedef enum
 {

--- a/muxer.c
+++ b/muxer.c
@@ -712,13 +712,11 @@ static int open_input_files( muxer_t *muxer )
                 if( opt->isom )
                     add_brand( opt, ISOM_BRAND_TYPE_AVC1 );
             }
-#if 0
             else if( lsmash_check_codec_type_identical( codec_type, ISOM_CODEC_TYPE_HVC1_VIDEO ) )
             {
                 if( !opt->isom && opt->qtff )
                     return ERROR_MSG( "the input seems HEVC, at present available only for ISO Base Media file format.\n" );
             }
-#endif
             else if( lsmash_check_codec_type_identical( codec_type, ISOM_CODEC_TYPE_VC_1_VIDEO ) )
             {
                 if( !opt->isom && opt->qtff )


### PR DESCRIPTION
14496-15 3rd edition is now officially in FDIS ballot, in other
words there is no possibility of further technical edits for this
version of the specification.

This reverts commit 153572b12eed094fbf68c6770c753810d49e5a3a.
