### PR TITLE
Check whether the UUID fourcc is printable before printing

### DIFF
--- a/core/box.h
+++ b/core/box.h
@@ -2466,6 +2466,13 @@ void isom_bs_put_box_common( lsmash_bs_t *bs, void *box );
 
 int isom_check_compatibility( lsmash_file_t *file );
 
+#define isom_is_printable_char( c ) ( (c) >= 32 && (c) < 128 )
+#define isom_is_printable_4cc( fourcc ) \
+    ( isom_is_printable_char( (fourcc) >> 24 & 0xff ) && \
+      isom_is_printable_char( (fourcc) >> 16 & 0xff ) && \
+      isom_is_printable_char( (fourcc) >>  8 & 0xff ) && \
+      isom_is_printable_char( (fourcc) >>  0 & 0xff ) )
+
 #define isom_4cc2str( fourcc ) (const char [5]){ (fourcc) >> 24, (fourcc) >> 16, (fourcc) >> 8, (fourcc), 0 }
 
 isom_trak_t *isom_get_trak( lsmash_file_t *file, uint32_t track_ID );

--- a/core/print.c
+++ b/core/print.c
@@ -173,7 +173,8 @@ static inline int isom_print_simple( FILE *fp, isom_box_t *box, int level, char 
         lsmash_ifprintf( fp, indent, "position = %"PRIu64"\n", box->pos );
         lsmash_ifprintf( fp, indent, "size = %"PRIu64"\n", box->size );
         lsmash_ifprintf( fp, indent++, "usertype\n" );
-        lsmash_ifprintf( fp, indent, "type = %s\n", isom_4cc2str( box->type.user.fourcc ) );
+        if( isom_is_printable_4cc( box->type.user.fourcc ) )
+            lsmash_ifprintf( fp, indent, "type = %s\n", isom_4cc2str( box->type.user.fourcc ) );
         lsmash_ifprintf( fp, indent, "name = %s\n", name );
         lsmash_ifprintf( fp, indent, "uuid = 0x%08"PRIx32"-%04"PRIx16"-%04"PRIx16"-%04"PRIx16"-%04"PRIx16"0x%08"PRIx32"\n",
                          box->type.user.fourcc,
@@ -225,7 +226,8 @@ static int isom_print_unknown( FILE *fp, lsmash_file_t *file, isom_box_t *box, i
         lsmash_ifprintf( fp, indent, "position = %"PRIu64"\n", box->pos );
         lsmash_ifprintf( fp, indent, "size = %"PRIu64"\n", box->size );
         lsmash_ifprintf( fp, indent++, "usertype\n" );
-        lsmash_ifprintf( fp, indent, "type = %s\n", isom_4cc2str( box->type.user.fourcc ) );
+        if( isom_is_printable_4cc( box->type.user.fourcc ) )
+            lsmash_ifprintf( fp, indent, "type = %s\n", isom_4cc2str( box->type.user.fourcc ) );
         lsmash_ifprintf( fp, indent, "uuid = 0x%08"PRIx32"-%04"PRIx16"-%04"PRIx16"-%04"PRIx16"-%04"PRIx16"%08"PRIx32"\n",
                          box->type.user.fourcc,
                          (box->type.user.id[0] << 8) | box->type.user.id[1], (box->type.user.id[2] << 8) | box->type.user.id[3],


### PR DESCRIPTION
This avoids garbling the terminal if the UUID doesn't start with
a printable fourcc.
