### PR TITLE
DLL Stuff

### DIFF
--- a/L-SMASH.sln
+++ b/L-SMASH.sln
@@ -4,6 +4,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "liblsmash", "L-SMASH.vcxproj", "{9CFCDBDD-FD7D-48E9-9AE8-6CEB544D7E4B}"
+	ProjectSection(ProjectDependencies) = postProject
+		{4BCB601E-A480-4DCE-95DD-F4737D9D57C9} = {4BCB601E-A480-4DCE-95DD-F4737D9D57C9}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "remuxer", "cli\remuxer.vcxproj", "{EDB3F1A6-BCDD-47D2-80AD-6E09BEEC8CBB}"
 EndProject
@@ -14,6 +17,8 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "timelineeditor", "cli\timelineeditor.vcxproj", "{A0F6445C-CBCD-4B85-A0F7-D8250A6B021E}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cli", "cli\cli.vcxproj", "{DF39D172-117D-4AAC-9415-01E55DCA6D9E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dllexportgen", "windows\dllexportgen.csproj", "{4BCB601E-A480-4DCE-95DD-F4737D9D57C9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -61,6 +66,14 @@ Global
 		{DF39D172-117D-4AAC-9415-01E55DCA6D9E}.CLIRelease|Win32.Build.0 = CLIRelease|Win32
 		{DF39D172-117D-4AAC-9415-01E55DCA6D9E}.Debug|Win32.ActiveCfg = Debug|Win32
 		{DF39D172-117D-4AAC-9415-01E55DCA6D9E}.Release|Win32.ActiveCfg = Release|Win32
+		{4BCB601E-A480-4DCE-95DD-F4737D9D57C9}.CLIDebug|Win32.ActiveCfg = CLIDebug|x86
+		{4BCB601E-A480-4DCE-95DD-F4737D9D57C9}.CLIDebug|Win32.Build.0 = CLIDebug|x86
+		{4BCB601E-A480-4DCE-95DD-F4737D9D57C9}.CLIRelease|Win32.ActiveCfg = CLIRelease|x86
+		{4BCB601E-A480-4DCE-95DD-F4737D9D57C9}.CLIRelease|Win32.Build.0 = CLIRelease|x86
+		{4BCB601E-A480-4DCE-95DD-F4737D9D57C9}.Debug|Win32.ActiveCfg = Debug|x86
+		{4BCB601E-A480-4DCE-95DD-F4737D9D57C9}.Debug|Win32.Build.0 = Debug|x86
+		{4BCB601E-A480-4DCE-95DD-F4737D9D57C9}.Release|Win32.ActiveCfg = Release|x86
+		{4BCB601E-A480-4DCE-95DD-F4737D9D57C9}.Release|Win32.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/L-SMASH.vcxproj
+++ b/L-SMASH.vcxproj
@@ -90,6 +90,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ModuleDefinitionFile>lsmash.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='CLIDebug|Win32'">
@@ -123,6 +124,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <ModuleDefinitionFile>lsmash.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='CLIRelease|Win32'">

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ uninstall:
 	$(RM) $(addprefix $(DESTDIR)$(bindir)/, $(TOOLS_ALL) $(TOOLS_ALL:%=%.exe) liblsmash.dll cyglsmash.dll)
 
 clean:
-	$(RM) */*.o *.a *.so* *.dll *.dylib $(addprefix cli/, *.exe $(TOOLS_ALL)) .depend
+	$(RM) */*.o *.a *.so* *.dll *.dylib $(addprefix cli/, *.exe $(TOOLS_ALL)) .depend *.ver
 
 distclean: clean
 	$(RM) config.* *.pc

--- a/configure
+++ b/configure
@@ -58,7 +58,7 @@ cc_check()
 
 #-----------------------------------------------------------------------------
 
-rm -f config.* .depend conftest* liblsmash.pc
+rm -f config.* .depend conftest* liblsmash.pc *.ver
 
 
 echo
@@ -106,7 +106,7 @@ TOOLS=""
 
 CFLAGS="-Wshadow -Wall -std=c99 -pedantic -I. -I$SRCDIR"
 LDFLAGS="-L."
-SO_LDFLAGS='-shared -Wl,-soname,$@'
+SO_LDFLAGS='-shared -Wl,-soname,$@ -Wl,--version-script,liblsmash.ver'
 LIBS="-lm"
 
 for opt; do
@@ -200,7 +200,7 @@ case "$TARGET_OS" in
         EXT=".exe"
         SHARED_EXT=".dll"
         IMPLIB="liblsmash.dll.a"
-        SO_LDFLAGS="-shared -Wl,--out-implib,$IMPLIB"
+        SO_LDFLAGS="-shared -Wl,--out-implib,$IMPLIB -Wl,--version-script,liblsmash.ver"
         CFLAGS="$CFLAGS -D__USE_MINGW_ANSI_STDIO=1"
         ;;
     *cygwin*)
@@ -208,11 +208,11 @@ case "$TARGET_OS" in
         SHARED_NAME="cyglsmash"
         SHARED_EXT=".dll"
         IMPLIB="liblsmash.dll.a"
-        SO_LDFLAGS="-shared -Wl,--out-implib,$IMPLIB"
+        SO_LDFLAGS="-shared -Wl,--out-implib,$IMPLIB -Wl,--version-script,liblsmash.ver"
         ;;
     *darwin*)
         SHARED_EXT=".dylib"
-        SO_LDFLAGS="-dynamiclib -Wl,-undefined,suppress -Wl,-read_only_relocs,suppress -Wl,-flat_namespace"
+        SO_LDFLAGS="-dynamiclib -Wl,-undefined,suppress -Wl,-read_only_relocs,suppress -Wl,-flat_namespace -Wl,--version-script,liblsmash.ver"
         ;;
     *solaris*)
         #patches welcome
@@ -376,6 +376,9 @@ cat >> config.h << EOF
 #define LSMASH_REV "$REV"
 #define LSMASH_GIT_HASH "$HASH"
 EOF
+
+
+sed "s/\\\$MAJOR/$MAJVER/" $SRCDIR/liblsmash.v > liblsmash.ver
 
 
 cat >> liblsmash.pc << EOF

--- a/liblsmash.v
+++ b/liblsmash.v
@@ -1,0 +1,6 @@
+LSMASH_$MAJOR {
+    global: lsmash_*;
+            ISOM_*;
+            QT_*;
+    local: *;
+};

--- a/windows/App.config
+++ b/windows/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/windows/dllexportgen.cs
+++ b/windows/dllexportgen.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace dllexportgen
+{
+    class dllexportgen
+    {
+        static void Main(string[] args)
+        {
+            var sw = new StreamReader(args[0] + "\\lsmash.h");
+            var so = new StreamWriter(args[0] + "\\lsmash.def");
+            string prevline = "";
+
+            so.WriteLine("EXPORTS");
+
+            while (!sw.EndOfStream)
+            {
+                var funcregex = new Regex("^\\($");
+                var typeregex = new Regex("^DEFINE_(ISOM|QTFF)_CODEC_TYPE\\(");
+
+                string line = sw.ReadLine();
+
+                if (funcregex.IsMatch(line) && prevline != "")
+                {
+                    /* Export all public API functions. */
+                    var sub = new Regex(".+\\s+\\*{0,1}(.+)");
+                    string newline = sub.Replace(prevline, "$1");
+
+                    so.Write("    ");
+                    so.WriteLine(newline);
+                }
+                else if (typeregex.IsMatch(line))
+                {
+                    /* Export all codec types. */
+                    var sub = new Regex("^.+\\s+((ISOM|QT|LSMASH)_CODEC_TYPE_.+?),\\s+.+");
+                    string newline = sub.Replace(line, "$1");
+
+                    so.Write("    ");
+                    so.WriteLine(newline);
+                }
+
+                prevline = line;
+            }
+
+            sw.Close();
+
+            /* Non-public symbols for the cli apps. */
+            so.Write("lsmash_importer_open\n" +
+                     "lsmash_importer_get_access_unit\n" +
+                     "lsmash_importer_close\n" +
+                     "lsmash_importer_get_track_count\n" +
+                     "lsmash_importer_get_last_delta\n" +
+                     "lsmash_importer_construct_timeline\n" +
+                     "lsmash_duplicate_summary\n" +
+                     "lsmash_string_from_wchar\n" +
+                     "lsmash_win32_fopen");
+
+            so.Flush();
+            so.Close();
+        }
+    }
+}

--- a/windows/dllexportgen.csproj
+++ b/windows/dllexportgen.csproj
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4BCB601E-A480-4DCE-95DD-F4737D9D57C9}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>dllexportgen</RootNamespace>
+    <AssemblyName>dllexportgen</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject>dllexportgen.dllexportgen</StartupObject>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'CLIRelease|x86'">
+    <OutputPath>bin\x86\CLIRelease\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'CLIDebug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\CLIDebug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="dllexportgen.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>$(TargetPath) $(SolutionDir)</PostBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
The first commit, which adds the `extern "C"` stuff is an RFC. We could simply require the user to:

```C
extern "C" {
#include <lsmash.h>
}
```

rather than automatically do it.

Fixes #41.