### PR TITLE
common/osdep: Properly define _POSIX_C_SOURCE on non-Windows

### DIFF
--- a/common/osdep.h
+++ b/common/osdep.h
@@ -34,6 +34,7 @@
 #define lsmash_fseek fseeko64
 #define lsmash_ftell ftello64
 #else
+#define _POSIX_C_SOURCE 200809L
 #define lsmash_fseek fseeko
 #define lsmash_ftell ftello
 #endif


### PR DESCRIPTION
This is required for stricter libc implementations such as musl,
which do not expose fseeko and ftello by default, in order to
strictly follow the spec.