### PR TITLE
importer/vc1_imp: prevent going into infinite loop when data is all 0s

### DIFF
--- a/common/bytes.c
+++ b/common/bytes.c
@@ -404,8 +404,11 @@ uint8_t lsmash_bs_show_byte( lsmash_bs_t *bs, uint32_t offset )
         if( offset >= lsmash_bs_get_remaining_buffer_size( bs ) )
         {
             if( bs->eof )
+            {
                 /* No more read from both the stream and the buffer. */
+                bs->eob = 1;
                 return 0;
+            }
             /* We need increase the buffer size. */
             bs_alloc( bs, bs->buffer.pos + offset + 1 );
             bs_fill_buffer( bs );

--- a/importer/vc1_imp.c
+++ b/importer/vc1_imp.c
@@ -470,7 +470,7 @@ static int vc1_importer_probe( importer_t *importer )
     int err;
     while( 1 )
     {
-        if( lsmash_bs_is_error( bs ) )
+        if( lsmash_bs_is_error( bs ) || bs->eob )
         {
             err = LSMASH_ERR_IO;
             goto fail;


### PR DESCRIPTION
if you feed a file that is all 0s, vc1_imp.c goes into an infinite loop
