### PR TITLE
cli: Refresh progress bar in a sane frequency && mp3_imp: Fix probing multiple ID3s

### DIFF
--- a/cli/muxer.c
+++ b/cli/muxer.c
@@ -1070,7 +1070,7 @@ static int do_mux( muxer_t *muxer )
     uint32_t num_consecutive_sample_skip = 0;
     uint32_t num_active_input_tracks = out_movie->num_of_tracks;
     uint64_t total_media_size = 0;
-    uint8_t  sample_count = 0;
+    uint32_t progress_pos = 0;
     while( 1 )
     {
         input_t *input = &muxer->input[current_input_number - 1];
@@ -1153,10 +1153,10 @@ static int do_mux( muxer_t *muxer )
                     total_media_size += sample_size;
                     ++ out_track->current_sample_number;
                     num_consecutive_sample_skip = 0;
-                    /* Print, per 256 samples, total size of imported media. */
-                    if( ++sample_count == 0 )
+                    /* Print, per 4 megabytes, total size of imported media. */
+                    if( (total_media_size >> 22) > progress_pos )
                     {
-                        REFRESH_CONSOLE;
+                        progress_pos = total_media_size >> 22;
                         eprintf( "Importing: %"PRIu64" bytes\r", total_media_size );
                     }
                 }
@@ -1203,8 +1203,13 @@ static int do_mux( muxer_t *muxer )
 
 static int moov_to_front_callback( void *param, uint64_t written_movie_size, uint64_t total_movie_size )
 {
+    static uint32_t progress_pos = 0;
+    if ( (written_movie_size >> 24) <= progress_pos )
+        return 0;
     REFRESH_CONSOLE;
     eprintf( "Finalizing: [%5.2lf%%]\r", total_movie_size ? ((double)written_movie_size / total_movie_size) * 100.0 : 0 );
+    // Print, per 16 megabytes
+    progress_pos = written_movie_size >> 24;
     return 0;
 }
 

--- a/cli/timelineeditor.c
+++ b/cli/timelineeditor.c
@@ -1119,7 +1119,7 @@ int main( int argc, char *argv[] )
     uint32_t num_consecutive_sample_skip = 0;
     uint32_t num_active_input_tracks     = out_movie->num_tracks;
     uint64_t total_media_size            = 0;
-    uint8_t  sample_count                = 0;
+    uint32_t progress_pos                = 0;
     while( 1 )
     {
         track_t *in_track = &in_movie->track[ in_movie->current_track_number - 1 ];
@@ -1168,9 +1168,12 @@ int main( int argc, char *argv[] )
                     total_media_size += sample_size;
                     ++ in_track->current_sample_number;
                     num_consecutive_sample_skip = 0;
-                    /* Print, per 256 samples, total size of imported media. */
-                    if( ++sample_count == 0 )
+                    /* Print, per 4 megabytes, total size of imported media. */
+                    if( (total_media_size >> 22) > progress_pos )
+                    {
+                        progress_pos = total_media_size >> 22;
                         eprintf( "Importing: %"PRIu64" bytes\r", total_media_size );
+                    }
                 }
             }
             else

--- a/importer/mp3_imp.c
+++ b/importer/mp3_imp.c
@@ -442,9 +442,10 @@ static int mp4sys_mp3_probe( importer_t *importer )
     if( !mp3_imp )
         return LSMASH_ERR_MEMORY_ALLOC;
     lsmash_bs_t *bs = importer->bs;
-    if( lsmash_bs_show_byte( bs, 0 ) == 'I'
-     && lsmash_bs_show_byte( bs, 1 ) == 'D'
-     && lsmash_bs_show_byte( bs, 2 ) == '3' )
+    // Multiple ID3 headers could be present
+    while( lsmash_bs_show_byte( bs, 0 ) == 'I'
+        && lsmash_bs_show_byte( bs, 1 ) == 'D'
+        && lsmash_bs_show_byte( bs, 2 ) == '3' )
     {
         lsmash_bs_read_seek( bs, 6, SEEK_CUR );
         uint32_t size = 0;


### PR DESCRIPTION
The progress bar is refreshing so frequently and affects the performance when muxing or remuxing.
Now it's updated every 4 or 16 megabytes processed.