### PR TITLE
file: Add a parameter to disable probing in lsmash_read_file

### DIFF
--- a/core/file.c
+++ b/core/file.c
@@ -487,6 +487,7 @@ int lsmash_open_file
     param->max_async_tolerance = 2.0;
     param->max_chunk_size      = 4 * 1024 * 1024;
     param->max_read_size       = 4 * 1024 * 1024;
+    param->auto_probe          = 1;
     return 0;
 }
 
@@ -587,7 +588,7 @@ int64_t lsmash_read_file
             return (int64_t)LSMASH_ERR_MEMORY_ALLOC;
         file->importer = importer;
         lsmash_importer_set_file( importer, file );
-        ret = lsmash_importer_find( importer, "ISOBMFF/QTFF", !file->bs->unseekable );
+        ret = lsmash_importer_find( importer, "ISOBMFF/QTFF", param->auto_probe && !file->bs->unseekable );
         if( ret < 0 )
             return ret;
         if( param )

--- a/lsmash.h
+++ b/lsmash.h
@@ -48,7 +48,7 @@ extern "C" {
  ****************************************************************************/
 #define LSMASH_VERSION_MAJOR  2
 #define LSMASH_VERSION_MINOR 11
-#define LSMASH_VERSION_MICRO  4
+#define LSMASH_VERSION_MICRO  5
 
 #define LSMASH_VERSION_INT( a, b, c ) (((a) << 16) | ((b) << 8) | (c))
 
@@ -255,6 +255,7 @@ typedef struct
     uint64_t max_chunk_size;            /* max size per chunk in bytes. 4*1024*1024 (4MiB) is default value. */
     /** demuxing only **/
     uint64_t max_read_size;             /* max size of reading from the file at a time. 4*1024*1024 (4MiB) is default value. */
+    int auto_probe;                     /* whether or not to auto probe in lsmash_read_file. */
 } lsmash_file_parameters_t;
 
 typedef int (*lsmash_adhoc_remux_callback)( void *param, uint64_t done, uint64_t total );


### PR DESCRIPTION
## Description

Probing can be a very expensive operation if files are on a network drive,
or if the API user has provided a custom `read`/`write`/`seek` callbacks.

Add a file a parameter to allow API users to force name-matching instead
of auto-probing in `lsmash_read_file`.
## Things I'm Not Sure About
- I'm not sure if I added this to the correct struct. `lsmash_file_parameters_t`
  seemed correct, but I'm not 100% sure.
- I'm not sure I set it to the default of `1` in all the places I should have.
- I'm not sure if I should have used `lsmash_boolean_t` for the type instead of `int`.
- I'm not 100% sure the new API is even necessary, but I could not figure out how to
  skip probing in `lsmash_read_file` without it.
