### PR TITLE
Eliminated inappropriate uses of '\r' as EOL mark and attempts to mess with terminal output.

### DIFF
--- a/cli/muxer.c
+++ b/cli/muxer.c
@@ -200,12 +200,10 @@ static void cleanup_muxer( muxer_t *muxer )
 }
 
 #define eprintf( ... ) fprintf( stderr, __VA_ARGS__ )
-#define REFRESH_CONSOLE eprintf( "                                                                               \r" )
 
 static int muxer_error( muxer_t *muxer, const char *message, ... )
 {
     cleanup_muxer( muxer );
-    REFRESH_CONSOLE;
     eprintf( "Error: " );
     va_list args;
     va_start( args, message );
@@ -216,7 +214,6 @@ static int muxer_error( muxer_t *muxer, const char *message, ... )
 
 static int error_message( const char *message, ... )
 {
-    REFRESH_CONSOLE;
     eprintf( "Error: " );
     va_list args;
     va_start( args, message );
@@ -1176,7 +1173,7 @@ static int do_mux( muxer_t *muxer )
                     if( (total_media_size >> 22) > progress_pos )
                     {
                         progress_pos = total_media_size >> 22;
-                        eprintf( "Importing: %"PRIu64" bytes\r", total_media_size );
+                        eprintf( "Importing: %"PRIu64" bytes\n", total_media_size );
                     }
                 }
                 else
@@ -1225,8 +1222,7 @@ static int moov_to_front_callback( void *param, uint64_t written_movie_size, uin
     static uint32_t progress_pos = 0;
     if ( (written_movie_size >> 24) <= progress_pos )
         return 0;
-    REFRESH_CONSOLE;
-    eprintf( "Finalizing: [%5.2lf%%]\r", total_movie_size ? ((double)written_movie_size / total_movie_size) * 100.0 : 0 );
+    eprintf( "Finalizing: [%5.2lf%%]\n", total_movie_size ? ((double)written_movie_size / total_movie_size) * 100.0 : 0 );
     /* Print, per 16 megabytes */
     progress_pos = written_movie_size >> 24;
     return 0;
@@ -1238,7 +1234,6 @@ static int finish_movie( output_t *output, option_t *opt )
     if( opt->chap_file )
         lsmash_set_tyrant_chapter( output->root, opt->chap_file, opt->add_bom_to_chpl );
     /* Close movie. */
-    REFRESH_CONSOLE;
     if( opt->optimize_pd )
     {
         lsmash_adhoc_remux_t moov_to_front;
@@ -1278,7 +1273,6 @@ int main( int argc, char *argv[] )
         return MUXER_ERR( "failed to do muxing.\n" );
     if( finish_movie( &muxer.output, &muxer.opt ) )
         return MUXER_ERR( "failed to finish movie.\n" );
-    REFRESH_CONSOLE;
     eprintf( "Muxing completed!\n" );
     cleanup_muxer( &muxer );        /* including lsmash_destroy_root() */
     return 0;

--- a/cli/remuxer.c
+++ b/cli/remuxer.c
@@ -239,12 +239,10 @@ static void cleanup_remuxer( remuxer_t *remuxer )
 }
 
 #define eprintf( ... ) fprintf( stderr, __VA_ARGS__ )
-#define REFRESH_CONSOLE eprintf( "                                                                               \r" )
 
 static int remuxer_error( remuxer_t *remuxer, const char *message, ... )
 {
     cleanup_remuxer( remuxer );
-    REFRESH_CONSOLE;
     eprintf( "[Error] " );
     va_list args;
     va_start( args, message );
@@ -255,7 +253,6 @@ static int remuxer_error( remuxer_t *remuxer, const char *message, ... )
 
 static int error_message( const char *message, ... )
 {
-    REFRESH_CONSOLE;
     eprintf( "[Error] " );
     va_list args;
     va_start( args, message );
@@ -266,7 +263,6 @@ static int error_message( const char *message, ... )
 
 static int warning_message( const char *message, ... )
 {
-    REFRESH_CONSOLE;
     eprintf( "[Warning] " );
     va_list args;
     va_start( args, message );
@@ -1164,7 +1160,6 @@ static void exclude_invalid_output_track( output_t *output, output_track_t *out_
                                           input_movie_t *in_movie, input_track_t *in_track,
                                           const char *message, ... )
 {
-    REFRESH_CONSOLE;
     eprintf( "[Warning] in %"PRIu32"/%"PRIu32" -> out %"PRIu32": ", in_movie->movie_ID, in_track->track_ID, out_track->track_ID );
     va_list args;
     va_start( args, message );
@@ -1347,8 +1342,7 @@ static int moov_to_front_callback( void *param, uint64_t written_movie_size, uin
     static uint32_t progress_pos = 0;
     if ( (written_movie_size >> 24) <= progress_pos )
         return 0;
-    REFRESH_CONSOLE;
-    eprintf( "Finalizing: [%5.2lf%%]\r", ((double)written_movie_size / total_movie_size) * 100.0 );
+    eprintf( "Finalizing: [%5.2lf%%]\n", ((double)written_movie_size / total_movie_size) * 100.0 );
     /* Print, per 16 megabytes */
     progress_pos = written_movie_size >> 24;
     return 0;
@@ -1650,7 +1644,7 @@ static int do_remux( remuxer_t *remuxer )
                         if( (total_media_size >> 22) > progress_pos )
                         {
                             progress_pos = total_media_size >> 22;
-                            eprintf( "Importing: %"PRIu64" bytes\r", total_media_size );
+                            eprintf( "Importing: %"PRIu64" bytes\n", total_media_size );
                         }
                     }
                     else
@@ -1741,7 +1735,6 @@ static int finish_movie( remuxer_t *remuxer )
     if( remuxer->chap_file )
         lsmash_set_tyrant_chapter( output->root, remuxer->chap_file, remuxer->add_bom_to_chpl );
     /* Finish muxing. */
-    REFRESH_CONSOLE;
     if( lsmash_finish_movie( output->root, &moov_to_front ) )
         return -1;
     return remuxer->frag_base_track ? 0 : lsmash_write_lsmash_indicator( output->root );
@@ -1819,7 +1812,6 @@ int main( int argc, char *argv[] )
         return REMUXER_ERR( "failed to construct timeline maps.\n" );
     if( finish_movie( &remuxer ) )
         return REMUXER_ERR( "failed to finish output movie.\n" );
-    REFRESH_CONSOLE;
     eprintf( "%s completed!\n", !remuxer.dash || remuxer.subseg_per_seg == 0 ? "Remuxing" : "Segmentation" );
     cleanup_remuxer( &remuxer );
     return 0;

--- a/cli/timelineeditor.c
+++ b/cli/timelineeditor.c
@@ -32,7 +32,6 @@
 #define LSMASH_MAX( a, b ) ((a) > (b) ? (a) : (b))
 
 #define eprintf( ... ) fprintf( stderr, __VA_ARGS__ )
-#define REFRESH_CONSOLE eprintf( "                                                                               \r" )
 
 typedef struct
 {
@@ -149,7 +148,6 @@ static void cleanup_timecode( timecode_t *timecode )
 
 static int error_message( const char* message, ... )
 {
-    REFRESH_CONSOLE;
     eprintf( "Error: " );
     va_list args;
     va_start( args, message );
@@ -160,7 +158,6 @@ static int error_message( const char* message, ... )
 
 static int warning_message( const char* message, ... )
 {
-    REFRESH_CONSOLE;
     eprintf( "Warning: " );
     va_list args;
     va_start( args, message );
@@ -870,7 +867,7 @@ static int check_white_brand( lsmash_brand_type brand )
 
 static int moov_to_front_callback( void *param, uint64_t written_movie_size, uint64_t total_movie_size )
 {
-    eprintf( "Finalizing: [%5.2lf%%]\r", ((double)written_movie_size / total_movie_size) * 100.0 );
+    eprintf( "Finalizing: [%5.2lf%%]\n", ((double)written_movie_size / total_movie_size) * 100.0 );
     return 0;
 }
 
@@ -1182,7 +1179,7 @@ int main( int argc, char *argv[] )
                     if( (total_media_size >> 22) > progress_pos )
                     {
                         progress_pos = total_media_size >> 22;
-                        eprintf( "Importing: %"PRIu64" bytes\r", total_media_size );
+                        eprintf( "Importing: %"PRIu64" bytes\n", total_media_size );
                     }
                 }
             }
@@ -1238,7 +1235,7 @@ int main( int argc, char *argv[] )
     moov_to_front.func = moov_to_front_callback;
     moov_to_front.buffer_size = 4*1024*1024;
     moov_to_front.param = NULL;
-    eprintf( "                                                                               \r" );
+    eprintf( "                                                                               \n" );
     if( lsmash_finish_movie( output.root, &moov_to_front )
      || lsmash_write_lsmash_indicator( output.root ) )
         return TIMELINEEDITOR_ERR( "Failed to finish output movie.\n" );

--- a/common/utils.c
+++ b/common/utils.c
@@ -90,15 +90,6 @@ void lsmash_log
     va_end( args );
 }
 
-void lsmash_log_refresh_line
-(
-    const void *class   /* unused, but for forward compatibility */
-)
-{
-    /* Assume 80 characters per line. */
-    fprintf( stderr, "%80c", '\r' );
-}
-
 uint32_t lsmash_count_bits
 (
     uint32_t bits

--- a/common/utils.h
+++ b/common/utils.h
@@ -103,11 +103,6 @@ void lsmash_log
     ...
 );
 
-void lsmash_log_refresh_line
-(
-    const void *class
-);
-
 uint32_t lsmash_count_bits
 (
     uint32_t bits

--- a/importer/nalu_imp.c
+++ b/importer/nalu_imp.c
@@ -735,7 +735,7 @@ static int h264_analyze_whole_stream
     uint32_t picture_stats[H264_PICTURE_TYPE_NONE + 1] = { 0 };
     uint32_t num_access_units = 0;
     lsmash_class_t *logger = &(lsmash_class_t){ "H.264" };
-    lsmash_log( &logger, LSMASH_LOG_INFO, "Analyzing stream as H.264\r" );
+    lsmash_log( &logger, LSMASH_LOG_INFO, "Analyzing stream as H.264\n" );
     h264_importer_t *h264_imp = (h264_importer_t *)importer->info;
     h264_info_t     *info     = &h264_imp->info;
     importer->status = IMPORTER_OK;
@@ -774,7 +774,6 @@ static int h264_analyze_whole_stream
         else
             ++picture_stats[ picture->type ];
     }
-    lsmash_log_refresh_line( &logger );
     lsmash_log( &logger, LSMASH_LOG_INFO,
                 "IDR: %"PRIu32", I: %"PRIu32", P: %"PRIu32", B: %"PRIu32", "
                 "SI: %"PRIu32", SP: %"PRIu32", Unknown: %"PRIu32"\n",
@@ -823,7 +822,6 @@ static int h264_analyze_whole_stream
     h264_imp->ts_list.timestamp    = timestamp;
     return 0;
 fail:
-    lsmash_log_refresh_line( &logger );
     lsmash_free( npt );
     return err;
 }
@@ -1394,7 +1392,7 @@ static int hevc_analyze_whole_stream
     uint32_t picture_stats[HEVC_PICTURE_TYPE_NONE + 1] = { 0 };
     uint32_t num_access_units = 0;
     lsmash_class_t *logger = &(lsmash_class_t){ "HEVC" };
-    lsmash_log( &logger, LSMASH_LOG_INFO, "Analyzing stream as HEVC\r" );
+    lsmash_log( &logger, LSMASH_LOG_INFO, "Analyzing stream as HEVC\n" );
     hevc_importer_t *hevc_imp = (hevc_importer_t *)importer->info;
     hevc_info_t     *info     = &hevc_imp->info;
     importer->status = IMPORTER_OK;
@@ -1436,7 +1434,6 @@ static int hevc_analyze_whole_stream
         else
             ++picture_stats[ picture->type ];
     }
-    lsmash_log_refresh_line( &logger );
     lsmash_log( &logger, LSMASH_LOG_INFO,
                 "IDR: %"PRIu32", CRA: %"PRIu32", BLA: %"PRIu32", I: %"PRIu32", P: %"PRIu32", B: %"PRIu32", Unknown: %"PRIu32"\n",
                 picture_stats[HEVC_PICTURE_TYPE_IDR], picture_stats[HEVC_PICTURE_TYPE_CRA],
@@ -1481,7 +1478,6 @@ static int hevc_analyze_whole_stream
     hevc_imp->ts_list.timestamp    = timestamp;
     return 0;
 fail:
-    lsmash_log_refresh_line( &logger );
     lsmash_free( npt );
     return err;
 }

--- a/importer/vc1_imp.c
+++ b/importer/vc1_imp.c
@@ -363,7 +363,7 @@ static int vc1_analyze_whole_stream
     uint32_t num_access_units  = 0;
     uint32_t num_consecutive_b = 0;
     lsmash_class_t *logger = &(lsmash_class_t){ "VC-1" };
-    lsmash_log( &logger, LSMASH_LOG_INFO, "Analyzing stream as VC-1\r" );
+    lsmash_log( &logger, LSMASH_LOG_INFO, "Analyzing stream as VC-1\n" );
     vc1_importer_t *vc1_imp = (vc1_importer_t *)importer->info;
     vc1_info_t     *info    = &vc1_imp->info;
     importer->status = IMPORTER_OK;
@@ -445,7 +445,6 @@ static int vc1_analyze_whole_stream
         for( uint32_t i = 0; i < num_access_units; i++ )
             timestamp[i].cts = timestamp[i].dts = i;
     lsmash_free( cts );
-    lsmash_log_refresh_line( &logger );
 #if 0
     for( uint32_t i = 0; i < num_access_units; i++ )
         fprintf( stderr, "Timestamp[%"PRIu32"]: DTS=%"PRIu64", CTS=%"PRIu64"\n", i, timestamp[i].dts, timestamp[i].cts );
@@ -454,7 +453,6 @@ static int vc1_analyze_whole_stream
     vc1_imp->ts_list.timestamp    = timestamp;
     return 0;
 fail:
-    lsmash_log_refresh_line( &logger );
     lsmash_free( cts );
     return err;
 }


### PR DESCRIPTION
Makes l-smash print messages without occasionally inserting '\r' and blank lines filled with spaces.
Since it is not an interactive util doing so only messed up the logs.
[before/after example](http://s1.postimg.org/y154ktve7/2017_03_06_214425.png)