### PR TITLE
utils: Adjust lsmash_fixed2double arguments to display negative values

### DIFF
--- a/common/utils.c
+++ b/common/utils.c
@@ -31,7 +31,7 @@
 #endif
 
 /*---- type ----*/
-double lsmash_fixed2double( uint64_t value, int frac_width )
+double lsmash_fixed2double( int64_t value, int frac_width )
 {
     return value / (double)(1ULL << frac_width);
 }

--- a/common/utils.h
+++ b/common/utils.h
@@ -70,7 +70,7 @@ typedef struct
 } lsmash_class_t;
 
 /*---- type ----*/
-double lsmash_fixed2double( uint64_t value, int frac_width );
+double lsmash_fixed2double( int64_t value, int frac_width );
 float lsmash_int2float32( uint32_t value );
 double lsmash_int2float64( uint64_t value );
 


### PR DESCRIPTION
This applies for example to display matrix values.