### PR TITLE
Added Dockerbuild & Github Actions Build with Auto release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+#Ignore the logs directory
+logs/
+
+#Ignoring the password file
+passwords.txt
+
+#Ignoring git and cache folders
+.git
+.cache
+
+#Ignoring all the markdown and class files
+*.md
+**/*.class
+
+.wsjcpp/*
+.vscode/*
+.DS_Store/*
+tmp/*

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,14 +35,13 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
           # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] &&  EXPLICIT_VERSION=$(echo $VERSION | sed -e 's/^v//') && VERSION=EXPLICIT_VERSION
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
 
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
 
           echo "IMAGE_ID=$IMAGE_ID" >> $GITHUB_ENV
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "EXPLICIT_VERSION=$EXPLICIT_VERSION" >> $GITHUB_ENV
 
       - name: Build image
         if: false
@@ -56,10 +55,8 @@ jobs:
           # ${{env.IMAGE_ID}} == $IMAGE_ID
           echo IMAGE_ID="${{env.IMAGE_ID}}"
           echo VERSION="${{env.VERSION}}"
-          echo EXPLICIT_VERSION="${{env.EXPLICIT_VERSION}}"
 
       - name: Push image
         run: |
           docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          [ ! -z "$EXPLICIT_VERSION" ] && docker tag $IMAGE_NAME $IMAGE_ID:$EXPLICIT_VERSION
           docker push $IMAGE_ID:$VERSION 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,7 @@ env:
   IMAGE_NAME: l-smash
 
 jobs:
+  if: false # temp disabled
   build_and_push:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,7 +66,6 @@ jobs:
           docker run --rm -v '/artifacts:/artifacts' $IMAGE_ID bash -c "cp -r /build/* /artifacts/"
           ls -la /artifacts
       - name: Release
-        if: false
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,11 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME
 
-      - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
       - name: Calculate Publishing Variables
         run: |
@@ -37,13 +33,21 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
           # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] &&  EXPLICIT_VERSION=$(echo $VERSION | sed -e 's/^v//') && VERSION=EXPLICIT_VERSION
 
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
 
           echo "IMAGE_ID=$IMAGE_ID" >> $GITHUB_ENV
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "EXPLICIT_VERSION=$EXPLICIT_VERSION" >> $GITHUB_ENV
+
+      - name: Build image
+        if: false
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
       - name: Echoing the publishing Variables
         run: |
@@ -54,4 +58,5 @@ jobs:
       - name: Push image
         run: |
           docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          [ ! -z "$EXPLICIT_VERSION" ] && docker tag $IMAGE_NAME $IMAGE_ID:$EXPLICIT_VERSION
           docker push $IMAGE_ID:$VERSION 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,22 +43,22 @@ jobs:
           echo "IMAGE_ID=$IMAGE_ID" >> $GITHUB_ENV
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
-      - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+      # - name: Build image
+      #   run: docker build . --file Dockerfile --tag $IMAGE_NAME
 
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
-      - name: Echoing the publishing Variables
-        run: |
-          # ${{env.IMAGE_ID}} == $IMAGE_ID
-          echo IMAGE_ID="${{env.IMAGE_ID}}"
-          echo VERSION="${{env.VERSION}}"
+      # - name: Echoing the publishing Variables
+      #   run: |
+      #     # ${{env.IMAGE_ID}} == $IMAGE_ID
+      #     echo IMAGE_ID="${{env.IMAGE_ID}}"
+      #     echo VERSION="${{env.VERSION}}"
 
-      - name: Push image
-        run: |
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+      # - name: Push image
+      #   run: |
+      #     docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+      #     docker push $IMAGE_ID:$VERSION
 
       - name: Extract Artifacts
         run: |
@@ -71,4 +71,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: |
-            ./artifacts
+            ./artifacts/*

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,21 +61,21 @@ jobs:
       #     docker push $IMAGE_ID:$VERSION
 
       - name: Extract Artifacts
-        if: [[ "${{ github.ref }}" == "refs/tags/"* ]]
+        if: "${{ github.ref }}" == "refs/tags/"*
         run: |
           mkdir -p ./artifacts/raw
           docker run --rm -v "$PWD/artifacts/raw:/artifacts" $IMAGE_ID bash -c "cp -r /build/* /artifacts/"
           ls -la ./artifacts
 
       - name: Packing Artifacts
-        if: [[ "${{ github.ref }}" == "refs/tags/"* ]]
+        if: "${{ github.ref }}" == "refs/tags/"*
         uses: papeloto/action-zip@v1
         with:
           files: ./artifacts/raw
           dest: ./artifacts/Artifacts.zip
 
       - name: Release
-        if: [[ "${{ github.ref }}" == "refs/tags/"* ]]
+        if: "${{ github.ref }}" == "refs/tags/"*
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -72,3 +72,5 @@ jobs:
         with:
           files: |
             ./artifacts/*
+            ./artifacts/*/*
+            ./artifacts/*/*/*

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,7 +62,7 @@ jobs:
       #     docker push $IMAGE_ID:$VERSION
 
       - name: Extract Artifacts
-        if: ${{ $HAS_VERSION_TAG == 1}}
+        if: ${{ env.HAS_VERSION_TAG == 1}}
         run: |
           mkdir -p ./artifacts/raw
           docker run --rm -v "$PWD/artifacts/raw:/artifacts" $IMAGE_ID bash -c "cp -r /build/* /artifacts/"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,6 +60,7 @@ jobs:
         run: |
           docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
           docker push $IMAGE_ID:$VERSION
+          [ "$VERSION" != "latest" ] && docker tag $IMAGE_NAME $IMAGE_ID:latest && docker push $IMAGE_ID:latest
 
       - name: Extract Artifacts
         if: ${{ env.HAS_VERSION_TAG == 1}}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,7 +43,6 @@ jobs:
           echo "EXPLICIT_VERSION=$EXPLICIT_VERSION" >> $GITHUB_ENV
 
       - name: Build image
-        if: false
         run: docker build . --file Dockerfile --tag $IMAGE_NAME
 
       - name: Log into registry
@@ -54,6 +53,7 @@ jobs:
           # ${{env.IMAGE_ID}} == $IMAGE_ID
           echo IMAGE_ID="${{env.IMAGE_ID}}"
           echo VERSION="${{env.VERSION}}"
+          echo EXPLICIT_VERSION="${{env.EXPLICIT_VERSION}}"
 
       - name: Push image
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
 
-    # Publish `v1.2.3` tags as releases.
+    # Publish `v1.2.3` tags as releases .
     tags:
       - v*
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,57 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+env:
+  IMAGE_NAME: l-smash
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+      - name: Calculate Publishing Variables
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo "IMAGE_ID=$IMAGE_ID" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Echoing the publishing Variables
+        run: |
+          # ${{env.IMAGE_ID}} == $IMAGE_ID
+          echo IMAGE_ID="${{env.IMAGE_ID}}"
+          echo VERSION="${{env.VERSION}}"
+
+      - name: Push image
+        run: |
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,18 +61,21 @@ jobs:
       #     docker push $IMAGE_ID:$VERSION
 
       - name: Extract Artifacts
+        if: [[ "${{ github.ref }}" == "refs/tags/"* ]]
         run: |
           mkdir -p ./artifacts/raw
           docker run --rm -v "$PWD/artifacts/raw:/artifacts" $IMAGE_ID bash -c "cp -r /build/* /artifacts/"
           ls -la ./artifacts
 
       - name: Packing Artifacts
+        if: [[ "${{ github.ref }}" == "refs/tags/"* ]]
         uses: papeloto/action-zip@v1
         with:
           files: ./artifacts/raw
           dest: ./artifacts/Artifacts.zip
 
       - name: Release
+        if: [[ "${{ github.ref }}" == "refs/tags/"* ]]
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Debugging
         run: |
           echo "${{ github.ref }}" 
+          echo "${{ github.event.head_commit.message }}" 
+ 
       - name: Calculate Publishing Variables
         run: |
           IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           mkdir -p ./artifacts
           docker run --rm -v "$PWD/artifacts:/artifacts" $IMAGE_ID bash -c "cp -r /build/* /artifacts/"
-          ls -la /artifacts
+          ls -la ./artifacts
       - name: Release
         uses: softprops/action-gh-release@v1
         env:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,13 +35,14 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
           # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//') && HAS_VERSION_TAG=1 || $HAS_VERSION_TAG=0
 
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
 
           echo "IMAGE_ID=$IMAGE_ID" >> $GITHUB_ENV
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "HAS_VERSION_TAG=$HAS_VERSION_TAG" >> $GITHUB_ENV
 
       # - name: Build image
       #   run: docker build . --file Dockerfile --tag $IMAGE_NAME
@@ -61,21 +62,21 @@ jobs:
       #     docker push $IMAGE_ID:$VERSION
 
       - name: Extract Artifacts
-        if: "${{ github.ref }}" == "refs/tags/"*
+        if: $HAS_VERSION_TAG
         run: |
           mkdir -p ./artifacts/raw
           docker run --rm -v "$PWD/artifacts/raw:/artifacts" $IMAGE_ID bash -c "cp -r /build/* /artifacts/"
           ls -la ./artifacts
 
       - name: Packing Artifacts
-        if: "${{ github.ref }}" == "refs/tags/"*
+        if: $HAS_VERSION_TAG
         uses: papeloto/action-zip@v1
         with:
           files: ./artifacts/raw
           dest: ./artifacts/Artifacts.zip
 
       - name: Release
-        if: "${{ github.ref }}" == "refs/tags/"*
+        if: $HAS_VERSION_TAG
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,9 +19,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
-
-
+      - name: Debugging
+        run: |
+          echo "${{ github.ref }}" 
       - name: Calculate Publishing Variables
         run: |
           IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
@@ -43,6 +43,7 @@ jobs:
           echo "EXPLICIT_VERSION=$EXPLICIT_VERSION" >> $GITHUB_ENV
 
       - name: Build image
+        if: false
         run: docker build . --file Dockerfile --tag $IMAGE_NAME
 
       - name: Log into registry

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
 
-    # Publish `v1.2.3` tags as releases .
+    # Publish `v1.2.3` tags as releases.
     tags:
       - v*
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,22 +44,22 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "HAS_VERSION_TAG=$HAS_VERSION_TAG" >> $GITHUB_ENV
 
-      # - name: Build image
-      #   run: docker build . --file Dockerfile --tag $IMAGE_NAME
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
 
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
-      # - name: Echoing the publishing Variables
-      #   run: |
-      #     # ${{env.IMAGE_ID}} == $IMAGE_ID
-      #     echo IMAGE_ID="${{env.IMAGE_ID}}"
-      #     echo VERSION="${{env.VERSION}}"
+      - name: Echoing the publishing Variables
+        run: |
+          # ${{env.IMAGE_ID}} == $IMAGE_ID
+          echo IMAGE_ID="${{env.IMAGE_ID}}"
+          echo VERSION="${{env.VERSION}}"
 
-      # - name: Push image
-      #   run: |
-      #     docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-      #     docker push $IMAGE_ID:$VERSION
+      - name: Push image
+        run: |
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION
 
       - name: Extract Artifacts
         if: ${{ env.HAS_VERSION_TAG == 1}}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,4 +58,18 @@ jobs:
       - name: Push image
         run: |
           docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION 
+          docker push $IMAGE_ID:$VERSION
+
+      - name: Extract Artifacts
+        run: |
+          mkdir -p /artifacts
+          docker run --rm -v '/artifacts:/artifacts' $IMAGE_ID bash -c "cp -r /build/* /artifacts/"
+          ls -la /artifacts
+      - name: Release
+        if: false
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            /artifacts

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,21 +62,19 @@ jobs:
       #     docker push $IMAGE_ID:$VERSION
 
       - name: Extract Artifacts
-        if: $HAS_VERSION_TAG
+        if: ${{ $HAS_VERSION_TAG == 1}}
         run: |
           mkdir -p ./artifacts/raw
           docker run --rm -v "$PWD/artifacts/raw:/artifacts" $IMAGE_ID bash -c "cp -r /build/* /artifacts/"
           ls -la ./artifacts
 
       - name: Packing Artifacts
-        if: $HAS_VERSION_TAG
         uses: papeloto/action-zip@v1
         with:
           files: ./artifacts/raw
           dest: ./artifacts/Artifacts.zip
 
       - name: Release
-        if: $HAS_VERSION_TAG
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,15 +62,20 @@ jobs:
 
       - name: Extract Artifacts
         run: |
-          mkdir -p ./artifacts
-          docker run --rm -v "$PWD/artifacts:/artifacts" $IMAGE_ID bash -c "cp -r /build/* /artifacts/"
+          mkdir -p ./artifacts/raw
+          docker run --rm -v "$PWD/artifacts/raw:/artifacts" $IMAGE_ID bash -c "cp -r /build/* /artifacts/"
           ls -la ./artifacts
+
+      - name: Packing Artifacts
+        uses: papeloto/action-zip@v1
+        with:
+          files: ./artifacts/raw
+          dest: ./artifacts/Artifacts.zip
+
       - name: Release
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: |
-            ./artifacts/*
-            ./artifacts/*/*
-            ./artifacts/*/*/*
+            ./artifacts/Artifacts.zip

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,7 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
           # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//') && HAS_VERSION_TAG=1 || $HAS_VERSION_TAG=0
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//') && HAS_VERSION_TAG=1 || HAS_VERSION_TAG=0
 
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
@@ -69,12 +69,14 @@ jobs:
           ls -la ./artifacts
 
       - name: Packing Artifacts
+        if: ${{ env.HAS_VERSION_TAG == 1}}
         uses: papeloto/action-zip@v1
         with:
           files: ./artifacts/raw
           dest: ./artifacts/Artifacts.zip
 
       - name: Release
+        if: ${{ env.HAS_VERSION_TAG == 1}}
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,8 +62,8 @@ jobs:
 
       - name: Extract Artifacts
         run: |
-          mkdir -p /artifacts
-          docker run --rm -v '/artifacts:/artifacts' $IMAGE_ID bash -c "cp -r /build/* /artifacts/"
+          mkdir -p ./artifacts
+          docker run --rm -v "$PWD/artifacts:/artifacts" $IMAGE_ID bash -c "cp -r /build/* /artifacts/"
           ls -la /artifacts
       - name: Release
         uses: softprops/action-gh-release@v1
@@ -71,4 +71,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: |
-            /artifacts
+            ./artifacts

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,7 +44,6 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Build image
-        if: false
         run: docker build . --file Dockerfile --tag $IMAGE_NAME
 
       - name: Log into registry

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,36 @@
+name: TestBuild
+
+on:
+  push:
+    branches:
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+env:
+  IMAGE_NAME: l-smash
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Debugging
+        run: |
+          echo "${{ github.ref }}" 
+          echo "${{ github.event.head_commit.message }}" 
+      - name: Prepare Env
+        run: |
+          apt update && apt install -y git build-essential autoconf automake dos2unix
+          dos2unix configure && chmod +x configure
+      - name: Build
+        run: |
+            mkdir -p ./build/bin
+            mkdir -p ./build/lib
+            mkdir -p ./build/include
+            ./configure --prefix='./build' --enable-shared --disable-static
+            make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# FROM debian:bullseye
+
 FROM ubuntu:20.04
 RUN apt update && apt install -y git build-essential autoconf automake dos2unix
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,6 @@ RUN ./configure --prefix='/usr' --enable-shared --disable-static  \
 # use this to release
 # docker build . -t l-smash ^C
 # docker tag l-smash l-smash:2.14.6-beta
+
+# use this to copy artifacts:
+# docker run --rm -v "$PWD/artifacts:/artifacts" l-smash bash -c "cp -r /build/* /artifacts/" 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:20.04
+RUN apt update && apt install -y git build-essential autoconf automake dos2unix
+
+WORKDIR /app
+ADD . ./
+
+RUN dos2unix configure && chmod +x configure
+
+
+RUN ./configure --prefix='/usr' --enable-shared --disable-static  \
+    && make \
+    && make install
+
+
+# use this to release
+# docker build . -t l-smash ^C
+# docker tag l-smash l-smash:2.14.6-beta

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,12 @@ RUN dos2unix configure && chmod +x configure
 
 RUN ./configure --prefix='/usr' --enable-shared --disable-static  \
     && make \
+    && make install \
+    && mkdir -p /build/bin \
+    && mkdir -p /build/lib \
+    && mkdir -p /build/include \
+    &&  ./configure --prefix='/build' --enable-shared --disable-static \
     && make install
-
 
 # use this to release
 # docker build . -t l-smash ^C

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,13 @@ RUN ./configure --prefix='/usr' --enable-shared --disable-static  \
     &&  ./configure --prefix='/build' --enable-shared --disable-static \
     && make install
 
-# use this to release
-# docker build . -t l-smash ^C
-# docker tag l-smash l-smash:2.14.6-beta
+RUN rm -rf /app/*
+
+# use this to build
+#   docker build . -t l-smash
+
+# this to release
+#   docker tag l-smash l-smash:2.14.6-beta
 
 # use this to copy artifacts:
-# docker run --rm -v "$PWD/artifacts:/artifacts" l-smash bash -c "cp -r /build/* /artifacts/" 
+#   docker run --rm -v "$PWD/artifacts:/artifacts" l-smash bash -c "cp -r /build/* /artifacts/" 


### PR DESCRIPTION
``` sh
# use this to build
docker build . -t l-smash

# this to release
 docker tag l-smash l-smash:2.14.6-beta

# use this to copy artifacts:
docker run --rm -v "$PWD/artifacts:/artifacts" l-smash bash -c "cp -r /build/* /artifacts/" 

# Create a new version for release
git tag v2.14.7-beta

# Publish
git push origin --tags
```

Push to master now causes 2 things:

- A new version is pushed to the github docker registry
- A new version is released in ``/releases``, but only if you tag the commit

Advantages:
Ability to build locally in a clean manner (all artifacts are removed afterwards)
3rd party tools (in my case m4acut) can build on top of it

TODO's: Win&Mac builds ™️ 

Hope you like it :)
